### PR TITLE
czech language support, introduced dynamic weight for unicode blocks

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -10,6 +10,7 @@ Fast natural language detection.
 | Bengali (Bangla) | bn      |
 | German         | de        |
 | Greek          | el        |
+| Czech          | cs        |
 | English        | en        |
 | Spanish        | es        |
 | French         | fr        |

--- a/getlang_test.go
+++ b/getlang_test.go
@@ -486,6 +486,27 @@ func TestNonsense(t *testing.T) {
 		"")
 }
 
+func TestCzech(t *testing.T) {
+	var tests = []struct {
+		input         string
+		expectedLang  string
+		minConfidence float64
+	}{
+		{"Hlavní město České Republiky je Praha. Kolem mě létají ptáci.", "cs", 0.55},
+		{"Rok 2019 je tady – a můžeme volně podumat nad tím, co nám asi přinese.", "cs", 0.55},
+		{"Sám Nwelati přiznal, že o potížích s přiznáním ví už asi půl roku.", "cs", 0.55},
+		{"Dva měsíce se nic nedělo", "cs", 0.55},
+	}
+
+	for _, test := range tests {
+		ensureClassifiedWithConfidence(
+			t,
+			test.input,
+			test.expectedLang,
+			test.minConfidence)
+	}
+}
+
 func ensureClassifiedWithConfidence(t *testing.T, text string, expectedLang string, minConfidence float64) {
 	info := FromString(text)
 


### PR DESCRIPTION
Hello, I've added support for a czech language as well as support for dynamic weight for scripts (`scriptCountFactor`). 

The reason for that is that in a czech alphabet, there are few characters like `ř, š, ů` which you won't find in any other language. 

I hope you'll like my take on that. 